### PR TITLE
polarion_approve_automate() should compare commit hashes to get the git diff.

### DIFF
--- a/apps/polarion/polarion_set_automated.py
+++ b/apps/polarion/polarion_set_automated.py
@@ -20,12 +20,22 @@ def approve_tests(polarion_project_id: str, added_ids: list[str]) -> dict[str, l
 
 
 def remove_approved_tests(
-    polarion_project_id: str, branch: str, added_ids: list[str] | None = None
+    polarion_project_id: str,
+    branch: str | None = None,
+    previous_commit: str | None = None,
+    current_commit: str | None = None,
+    added_ids: list[str] | None = None,
 ) -> dict[str, list[str]]:
     removed_polarions = {}
     added_ids = added_ids or []
     if removed_ids := set(
-        find_polarion_ids(polarion_project_id=polarion_project_id, string_to_match="removed", branch=branch)
+        find_polarion_ids(
+            polarion_project_id=polarion_project_id,
+            string_to_match="removed",
+            branch=branch,
+            previous_commit=previous_commit,
+            current_commit=current_commit,
+        )
     ) - set(added_ids):
         LOGGER.info(f"Following polarion ids were removed: {removed_ids}")
         removed_polarions = update_polarion_ids(
@@ -43,25 +53,38 @@ def remove_approved_tests(
     default=os.path.expanduser("~/.config/python-utility-scripts/config.yaml"),
 )
 @click.option("--project-id", "-p", help="Provide the polarion project id")
-@click.option("--branch", "-b", help="Provide the github remote branch to run against", default="origin/main")
+@click.option("--previous-commit", "-p", help="Provide previous-commit to compare against")
+@click.option("--current-commit", "-c", help="Provide current-commit to compare with")
 @click.option("--verbose", default=False, is_flag=True)
-def polarion_approve_automate(config_file_path: str, project_id: str, branch: str, verbose: bool) -> None:
+def polarion_approve_automate(
+    config_file_path: str, project_id: str, previous_commit: str, current_commit: str, verbose: bool
+) -> None:
     if verbose:
         LOGGER.setLevel(logging.DEBUG)
         # since the utilities are in apps.polarion.polarion_utils, we need to change log level
         # for apps.polarion.polarion_utils as well
         logging.getLogger("apps.polarion.polarion_utils").setLevel(logging.DEBUG)
-
+    if not (current_commit and previous_commit):
+        LOGGER.error("Previous and current commit are required.")
     polarion_project_id = project_id or get_polarion_project_id(
         config_file_path=config_file_path, util_name="pyutils-polarion-set-automated"
     )
     added_polarions = {}
-    if added_ids := find_polarion_ids(polarion_project_id=polarion_project_id, string_to_match="added", branch=branch):
+    if added_ids := find_polarion_ids(
+        polarion_project_id=polarion_project_id,
+        string_to_match="added",
+        branch=None,
+        previous_commit=previous_commit,
+        current_commit=current_commit,
+    ):
         added_polarions = approve_tests(polarion_project_id=polarion_project_id, added_ids=added_ids)
         LOGGER.debug(f"Following polarion ids were marked automated and approved: {added_polarions.get('updated')}")
 
     removed_polarions = remove_approved_tests(
-        polarion_project_id=polarion_project_id, added_ids=added_ids, branch=branch
+        polarion_project_id=polarion_project_id,
+        added_ids=added_ids,
+        previous_commit=previous_commit,
+        current_commit=current_commit,
     )
     if removed_polarions.get("failed") or added_polarions.get("failed"):
         error = "Following polarion ids updates failed."

--- a/apps/polarion/polarion_set_automated.py
+++ b/apps/polarion/polarion_set_automated.py
@@ -53,8 +53,8 @@ def remove_approved_tests(
     default=os.path.expanduser("~/.config/python-utility-scripts/config.yaml"),
 )
 @click.option("--project-id", "-p", help="Provide the polarion project id")
-@click.option("--previous-commit", "-p", help="Provide previous-commit to compare against")
-@click.option("--current-commit", "-c", help="Provide current-commit to compare with")
+@click.option("--previous-commit", "-p", help="Provide previous-commit to compare against", required=True)
+@click.option("--current-commit", "-c", help="Provide current-commit to compare with", required=True)
 @click.option("--verbose", default=False, is_flag=True)
 def polarion_approve_automate(
     config_file_path: str, project_id: str, previous_commit: str, current_commit: str, verbose: bool
@@ -64,8 +64,7 @@ def polarion_approve_automate(
         # since the utilities are in apps.polarion.polarion_utils, we need to change log level
         # for apps.polarion.polarion_utils as well
         logging.getLogger("apps.polarion.polarion_utils").setLevel(logging.DEBUG)
-    if not (current_commit and previous_commit):
-        LOGGER.error("Previous and current commit are required.")
+
     polarion_project_id = project_id or get_polarion_project_id(
         config_file_path=config_file_path, util_name="pyutils-polarion-set-automated"
     )

--- a/apps/polarion/polarion_utils.py
+++ b/apps/polarion/polarion_utils.py
@@ -49,7 +49,12 @@ def validate_polarion_requirements(
         for _id in polarion_test_ids:
             has_req = False
             LOGGER.debug(f"Checking if {_id} verifies any requirement")
-            tc = TestCase(project_id=polarion_project_id, work_item_id=_id)
+            try:
+                tc = TestCase(project_id=polarion_project_id, work_item_id=_id)
+            except PyleroLibException:
+                LOGGER.error(f"{_id}: Test case not found.")
+                tests_with_missing_requirements.append(_id)
+                continue
             for link in tc.linked_work_items:
                 try:
                     Requirement(project_id=polarion_project_id, work_item_id=link.work_item_id)
@@ -59,7 +64,7 @@ def validate_polarion_requirements(
                     continue
 
             if not has_req:
-                LOGGER.error(f"{_id}: Is missing requirement")
+                LOGGER.error(f"{_id}: does not have associated requirement.")
                 tests_with_missing_requirements.append(_id)
     return tests_with_missing_requirements
 

--- a/apps/polarion/polarion_utils.py
+++ b/apps/polarion/polarion_utils.py
@@ -19,7 +19,15 @@ def git_diff(branch: str | None = None, current_commit: str | None = None, previ
     if branch and (previous_commit or current_commit):
         LOGGER.error("Branch and Previous or current commit are mutually exclusive command line options.")
         sys.exit(1)
-    diff_command = f"git diff {branch} HEAD" if branch else f"git diff {previous_commit} {current_commit}"
+
+    # Sanitize inputs to prevent command injection
+    if branch:
+        sanitized_branch = shlex.quote(branch)
+        diff_command = f"git diff {sanitized_branch} HEAD"
+    else:
+        sanitized_previous = shlex.quote(previous_commit) if previous_commit else ""
+        sanitized_current = shlex.quote(current_commit) if current_commit else ""
+        diff_command = f"git diff {sanitized_previous} {sanitized_current}"
     data = subprocess.check_output(shlex.split(diff_command))
     return data.decode()
 

--- a/tests/polarion/test_polarion_automated.py
+++ b/tests/polarion/test_polarion_automated.py
@@ -6,7 +6,7 @@ from pyhelper_utils.shell import run_command
 BASE_COMMAND = "poetry run python apps/polarion/polarion_set_automated.py --verbose"
 
 
-def test_missing_project_id_set_automated():
+def test_missing_required_params_set_automated():
     rc, _, err = run_command(
         command=shlex.split(BASE_COMMAND),
         verify_stderr=False,
@@ -14,5 +14,17 @@ def test_missing_project_id_set_automated():
         capture_output=False,
         stderr=subprocess.PIPE,
     )
-    assert "Previous and current commit" in err
+    assert "Missing option" in err
+    assert not rc
+
+
+def test_missing_project_id_set_automated():
+    rc, _, err = run_command(
+        command=shlex.split(f"{BASE_COMMAND} --previous-commit commit1 --current-commit commit2"),
+        verify_stderr=False,
+        check=False,
+        capture_output=False,
+        stderr=subprocess.PIPE,
+    )
+    assert "Polarion project id must be passed via config file or command line" in err
     assert not rc

--- a/tests/polarion/test_polarion_automated.py
+++ b/tests/polarion/test_polarion_automated.py
@@ -14,5 +14,5 @@ def test_missing_project_id_set_automated():
         capture_output=False,
         stderr=subprocess.PIPE,
     )
-    assert "Polarion project id must be passed via config file or command line" in err
+    assert "Previous and current commit" in err
     assert not rc


### PR DESCRIPTION
polarion_approve_automate() is supposed to run on PR submission. The payload generated contains clear information on before and after commit. It is best to compare those. On submission may repos has configuration to delete the branch immediately. We can avoid that issue as well. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Enhanced comparison functionality to use commit references. The command-line now requires specifying a previous commit and a current commit instead of a branch.
  - Improved diff processing, enabling comparisons based on specific commit ranges.

- **Tests**
  - Introduced a new test for handling missing required parameters, ensuring appropriate error messages are displayed.
  - Updated existing tests to validate functionality with new commit parameters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->