### PR TITLE
Add ability to skip a single function def, fix relative paths for exclude-files in unused-code

### DIFF
--- a/apps/unused_code/README.md
+++ b/apps/unused_code/README.md
@@ -49,7 +49,7 @@ def tmp2(
   x,
   y,
   z
-):  # skip-unused code
+):  # skip-unused-code
 ```
 Running this tool would exclude both functions `tmp1` and `tmp2`
 ```bash

--- a/apps/unused_code/README.md
+++ b/apps/unused_code/README.md
@@ -34,3 +34,26 @@ To run from CLI with `--exclude-files`
 ```bash
 pyutils-unusedcode --exclude-files 'my_exclude_file1.py,my_exclude_file2.py'
 ```
+
+## Excluding single functions in your code
+To skip single functions in your target repository you can add an inline comment to the function definition. The comment should match `# skip-unused-code`
+
+### Example:
+
+Given a target file main.py
+```python
+def tmp1():  # skip-unused-code
+  pass
+
+def tmp2(
+  x,
+  y,
+  z
+):  # skip-unused code
+```
+Running this tool would exclude both functions `tmp1` and `tmp2`
+```bash
+pyutils-unusedcode -v
+2025-01-01T00:00:00.1 apps.unused_code.unused_code DEBUG Skipping function due to comment: tmp1
+2025-01-01T00:00:00.2 apps.unused_code.unused_code DEBUG Skipping function due to comment: tmp2
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ output-format = "grouped"
 lint.extend-select = ["I"]
 
 [tool.ruff.format]
-exclude = [".git", ".venv", ".mypy_cache", ".tox", "__pycache__"]
+exclude = [".git", ".venv", ".mypy_cache", ".tox", "__pycache__", "unused_code_file_for_test.py"]
 
 [tool.poetry]
 name = "python-utility-scripts"

--- a/tests/unused_code/test_unused_code.py
+++ b/tests/unused_code/test_unused_code.py
@@ -14,17 +14,30 @@ def test_unused_code():
 
 
 def test_unused_code_file_list():
-    result = get_cli_runner().invoke(get_unused_functions, '--exclude-files "unused_code_file_for_test.py"')
+    result = get_cli_runner().invoke(
+        get_unused_functions, '--exclude-files "tests/unused_code/unused_code_file_for_test.py"'
+    )
     LOGGER.info(f"Result output: {result.output}, exit code: {result.exit_code}, exceptions: {result.exception}")
     assert result.exit_code == 0
     assert "Is not used anywhere in the code" not in result.output
+
+
+def test_unused_code_wrong_file_list():
+    result = get_cli_runner().invoke(get_unused_functions, '--exclude-files "unused_code_file_for_test.py"')
+    LOGGER.info(f"Result output: {result.output}, exit code: {result.exit_code}, exceptions: {result.exception}")
+    assert result.exit_code == 1
+    assert "Is not used anywhere in the code" in result.output
 
 
 def test_unused_code_function_list_exclude_all():
     result = get_cli_runner().invoke(get_unused_functions, '--exclude-function-prefixes "unused_code_"')
     LOGGER.info(f"Result output: {result.output}, exit code: {result.exit_code}, exceptions: {result.exception}")
-    assert result.exit_code == 0
-    assert "Is not used anywhere in the code" not in result.output
+    # No function def that starts with "unused_code_"
+    assert ":unused_code_" not in result.output
+    assert "check_me" in result.output
+    assert "check_me_too" in result.output
+    assert "foo" not in result.output
+    assert "bar" not in result.output
 
 
 def test_unused_code_function_list_exclude():
@@ -32,3 +45,17 @@ def test_unused_code_function_list_exclude():
     LOGGER.info(f"Result output: {result.output}, exit code: {result.exit_code}, exceptions: {result.exception}")
     assert result.exit_code == 1
     assert "Is not used anywhere in the code" in result.output
+    assert "unused_code_check_fail" in result.output
+    assert "unused_code_check_file" in result.output
+
+
+def test_skip_comment():
+    result = get_cli_runner().invoke(get_unused_functions)
+    LOGGER.info(f"Result output: {result.output}, exit code: {result.exit_code}, exceptions: {result.exception}")
+    assert result.exit_code == 1
+    assert "unused_code_check_fail" in result.output
+    assert "unused_code_check_file" in result.output
+    assert "check_me" in result.output
+    assert "check_me_too" in result.output
+    assert "foo" not in result.output
+    assert "bar" not in result.output

--- a/tests/unused_code/unused_code_file_for_test.py
+++ b/tests/unused_code/unused_code_file_for_test.py
@@ -13,7 +13,11 @@ def foo():  # skip-unused-code
     pass
 
 
-def bar(x: Any, y: Any, z: Any) -> None:  # skip-unused-code
+def bar(
+    x: Any,
+    y: Any,
+    z: Any
+) -> None:  # skip-unused-code
     pass
 
 

--- a/tests/unused_code/unused_code_file_for_test.py
+++ b/tests/unused_code/unused_code_file_for_test.py
@@ -1,6 +1,27 @@
+from typing import Any
+
+
 def unused_code_check_fail():
     pass
 
 
 def unused_code_check_file():
+    pass
+
+
+def foo():  # skip-unused-code
+    pass
+
+
+def bar(x: Any, y: Any, z: Any) -> None:  # skip-unused-code
+    pass
+
+
+def check_me():
+    # skip-unused code
+    pass
+
+
+# skip-unused-code
+def check_me_too():
     pass

--- a/tests/unused_code/unused_code_file_for_test.py
+++ b/tests/unused_code/unused_code_file_for_test.py
@@ -22,7 +22,7 @@ def bar(
 
 
 def check_me():
-    # skip-unused code
+    # skip-unused-code
     pass
 
 


### PR DESCRIPTION
Currently unused-code does not provide the ability to skip single function definitions, hence I've added the ability to skip via a specific comment added before the function definition (`# skip-unused-code`).
I've also fixed the behaviour of `--exclude-files`, which currently only works with file *names* and excludes all files of a given name in a project (e.g. `--exclude-files conftest.py` would exclude all conftest.py files in your project). Passing in relative paths to a specific file you want to exclude would be ignored, e.g. `--exclude-files sub/dir/confest.py` would be ignored and the specific sub/dir/conftest.py would be checked for unused code.
It now only excludes the file being specified, e.g. `--exclude-files conftest.py` would exclude conftest.py in the project root while `--exclude-files sub/dir/confest.py` (correctly) only excludes `sub/dir/confest.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a mechanism that lets users exclude specific functions from being checked for unused code by using the `# skip-unused-code` comment.
  - Enhanced file scanning with a two-stage evaluation and refined path-based checks, ensuring more accurate and targeted processing.
  - Added example functions in the documentation to illustrate the new exclusion feature.

- **Bug Fixes**
  - Improved test coverage with new scenarios and refined assertions for better validation of functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->